### PR TITLE
Update advertised latest version from 2.2 to 2.3

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -8,7 +8,7 @@
 PHP Manager 2 for IIS
 =====================
 
-.. attention:: Download 2.2 RTW now from `GitHub <https://github.com/phpmanager/phpmanager/releases>`_ !
+.. attention:: Download 2.3 RTW now from `GitHub <https://github.com/phpmanager/phpmanager/releases>`_ !
 
 PHP Manager for IIS is a GUI for managing multiple PHP installations on the
 IIS server.


### PR DESCRIPTION
Possible idea: have the docs page load the latest version number automatically using [GitHub's API](https://developer.github.com/v3/repos/releases/) so this number doesn't have to be manually incremented anymore.